### PR TITLE
Update wp-dbmanager.php

### DIFF
--- a/wp-dbmanager.php
+++ b/wp-dbmanager.php
@@ -641,7 +641,7 @@ function dbmanager_options() {
 			<tr>
 				<td valign="top"><strong><?php _e('Path To Backup:', 'wp-dbmanager'); ?></strong></td>
 				<td>
-					<input type="text" name="db_path" size="60" maxlength="100" value="<?php echo stripslashes($backup_options['path']); ?>" dir="ltr" />
+					<input type="text" name="db_path" size="60" maxlength="105" value="<?php echo stripslashes($backup_options['path']); ?>" dir="ltr" />
 					<p><?php _e('The absolute path to your database backup folder without trailing slash. Make sure the folder is writable.', 'wp-dbmanager'); ?></p>
 				</td>
 			</tr>


### PR DESCRIPTION
Increase maxlength value from 100 to 105 for "Path To Backup" field (Row 644). On one particular host (123reg) the way they store files means that for longer domain names, the character limit exceeds the maxlength 100.

History: Updated an old WP installation.  Host (123reg) had changed folder that client site resides in from 22 to 23.  But the long domain name meant the total number of characters for the full path exceeded 100, so could not update the new folder path until the change was made to the core wp-dbmanager.php file.  Understand this may not be universal, but thought would suggest it.

The 123reg path looks something like this:
`/websites/123reg/LinuxPackage##/accountname/fullwebsiteurl/public_html/wp-content/backup-db`

Thanks