### PR TITLE
Increase maxlength of "Path To Backup" textbox to 200

### DIFF
--- a/wp-dbmanager.php
+++ b/wp-dbmanager.php
@@ -699,7 +699,7 @@ function dbmanager_options() {
 			<tr>
 				<td valign="top"><strong><?php _e('Path To Backup:', 'wp-dbmanager'); ?></strong></td>
 				<td>
-					<input type="text" name="db_path" size="60" maxlength="105" value="<?php echo stripslashes($backup_options['path']); ?>" dir="ltr" />
+					<input type="text" name="db_path" size="60" maxlength="200" value="<?php echo stripslashes($backup_options['path']); ?>" dir="ltr" />
 					<p><?php _e('The absolute path to your database backup folder without trailing slash. Make sure the folder is writable.', 'wp-dbmanager'); ?></p>
 				</td>
 			</tr>


### PR DESCRIPTION
Thank you for the plugin, I have been using this plugin ever since I started using WordPress. <3

Some windows environments have paths longer than 105. Currently I am editing the `Path To Backup` textbox in dev tools to enter the longer paths. This simple change will help me and potentially others too. 

Before I realized this, I couldn't figure out why the path was not reading correctly. The path was being cut off and it was not apparent. 

Thanks for considering. 